### PR TITLE
Update dependencies, mainly namespace for AutoFixture 4

### DIFF
--- a/nuget/LazyEntityGraph.AutoFixture.nuspec
+++ b/nuget/LazyEntityGraph.AutoFixture.nuspec
@@ -15,7 +15,7 @@
     <tags>LazyEntityGraph AutoFixture</tags>
     <dependencies>
         <dependency id="LazyEntityGraph" version="1.0.0" />
-        <dependency id="AutoFixture" version="3.43.0" />
+        <dependency id="AutoFixture" version="4.0" />
     </dependencies>
   </metadata>
 </package>

--- a/nuget/LazyEntityGraph.Core.nuspec
+++ b/nuget/LazyEntityGraph.Core.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>LazyEntityGraph</tags>
     <dependencies>
-        <dependency id="Castle.Core" version="3.3.0" />
+        <dependency id="Castle.Core" version="4.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/LazyEntityGraph.AutoFixture/EntityPropertyRequestSpecification.cs
+++ b/src/LazyEntityGraph.AutoFixture/EntityPropertyRequestSpecification.cs
@@ -1,4 +1,4 @@
-﻿using Ploeh.AutoFixture.Kernel;
+﻿using AutoFixture.Kernel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LazyEntityGraph.AutoFixture/EntitySpecimenBuilder.cs
+++ b/src/LazyEntityGraph.AutoFixture/EntitySpecimenBuilder.cs
@@ -1,5 +1,5 @@
 ﻿using LazyEntityGraph.Core;
-using Ploeh.AutoFixture.Kernel;
+using AutoFixture.Kernel;
 using System;
 
 namespace LazyEntityGraph.AutoFixture

--- a/src/LazyEntityGraph.AutoFixture/InterceptorsFieldRequestSpecification.cs
+++ b/src/LazyEntityGraph.AutoFixture/InterceptorsFieldRequestSpecification.cs
@@ -1,5 +1,5 @@
 ﻿using Castle.DynamicProxy;
-using Ploeh.AutoFixture.Kernel;
+using AutoFixture.Kernel;
 using System;
 using System.Reflection;
 

--- a/src/LazyEntityGraph.AutoFixture/LazyEntityGraph.AutoFixture.csproj
+++ b/src/LazyEntityGraph.AutoFixture/LazyEntityGraph.AutoFixture.csproj
@@ -30,15 +30,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AutoFixture, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.3.0\lib\net452\AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.43.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.43.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Fare, Version=2.1.0.0, Culture=neutral, PublicKeyToken=ea68d375bf33a7c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fare.2.1.1\lib\net35\Fare.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
@@ -56,7 +59,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/LazyEntityGraph.AutoFixture/LazyEntityGraphCustomization.cs
+++ b/src/LazyEntityGraph.AutoFixture/LazyEntityGraphCustomization.cs
@@ -1,6 +1,6 @@
 ﻿using LazyEntityGraph.Core;
-using Ploeh.AutoFixture;
-using Ploeh.AutoFixture.Kernel;
+using AutoFixture;
+using AutoFixture.Kernel;
 using System;
 
 namespace LazyEntityGraph.AutoFixture

--- a/src/LazyEntityGraph.AutoFixture/MatchingTypeRequestionSpecification.cs
+++ b/src/LazyEntityGraph.AutoFixture/MatchingTypeRequestionSpecification.cs
@@ -1,4 +1,4 @@
-﻿using Ploeh.AutoFixture.Kernel;
+﻿using AutoFixture.Kernel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/LazyEntityGraph.AutoFixture/packages.config
+++ b/src/LazyEntityGraph.AutoFixture/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.43.0" targetFramework="net452" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="AutoFixture" version="4.3.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
+  <package id="Fare" version="2.1.1" targetFramework="net452" />
 </packages>

--- a/src/LazyEntityGraph.Core/LazyEntityGraph.Core.csproj
+++ b/src/LazyEntityGraph.Core/LazyEntityGraph.Core.csproj
@@ -30,13 +30,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
@@ -60,7 +60,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/LazyEntityGraph.Core/packages.config
+++ b/src/LazyEntityGraph.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
 </packages>

--- a/src/LazyEntityGraph.EntityFramework/App.config
+++ b/src/LazyEntityGraph.EntityFramework/App.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  </configSections>
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>

--- a/src/LazyEntityGraph.EntityFramework/LazyEntityGraph.EntityFramework.csproj
+++ b/src/LazyEntityGraph.EntityFramework/LazyEntityGraph.EntityFramework.csproj
@@ -31,12 +31,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -60,8 +58,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/LazyEntityGraph.EntityFramework/packages.config
+++ b/src/LazyEntityGraph.EntityFramework/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
 </packages>

--- a/src/LazyEntityGraph.Tests/App.config
+++ b/src/LazyEntityGraph.Tests/App.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  </configSections>
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <connectionStrings>
     <add name="BlogContext" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=Blog;Integrated Security=SSPI;" providerName="System.Data.SqlClient" />
   </connectionStrings>
@@ -21,7 +21,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3179" newVersion="2.1.0.3179" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.1.3858" newVersion="2.3.1.3858" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/LazyEntityGraph.Tests/EntityFramework/ModelMetadataGeneratorTests.cs
+++ b/src/LazyEntityGraph.Tests/EntityFramework/ModelMetadataGeneratorTests.cs
@@ -27,7 +27,7 @@ namespace LazyEntityGraph.Tests.EntityFramework
             var metadata = GetMetadata();
 
             // assert
-            metadata.EntityTypes.Should().BeEquivalentTo((IEnumerable)expected);
+            metadata.EntityTypes.Should().BeEquivalentTo(expected);
         }
 
 
@@ -51,7 +51,7 @@ namespace LazyEntityGraph.Tests.EntityFramework
             var metadata = GetMetadata();
 
             // assert
-            metadata.Constraints.Should().BeEquivalentTo((IEnumerable)expected);
+            metadata.Constraints.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/src/LazyEntityGraph.Tests/Integration/EndToEndTests.cs
+++ b/src/LazyEntityGraph.Tests/Integration/EndToEndTests.cs
@@ -2,20 +2,24 @@
 using LazyEntityGraph.AutoFixture;
 using LazyEntityGraph.EntityFramework;
 using LazyEntityGraph.Tests.EntityFramework;
-using Ploeh.AutoFixture;
-using Ploeh.AutoFixture.Xunit2;
+using AutoFixture;
+using AutoFixture.Xunit2;
 using Xunit;
+using System;
 
 namespace LazyEntityGraph.Tests.Integration
 {
     public class BlogModelDataAttribute : AutoDataAttribute
     {
-        public BlogModelDataAttribute()
-            : base(new Fixture()
-                  .Customize(new LazyEntityGraphCustomization(
-                      ModelMetadataGenerator.LoadFromCodeFirstContext(str => new BlogContext(str), true))))
+        public BlogModelDataAttribute() : base(CreateFixture)
         {
+        }
 
+        private static IFixture CreateFixture()
+        {
+            return new Fixture()
+                .Customize(new LazyEntityGraphCustomization(
+                                ModelMetadataGenerator.LoadFromCodeFirstContext(str => new BlogContext(str), true)));
         }
     }
 

--- a/src/LazyEntityGraph.Tests/Integration/ForeignKeyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ForeignKeyConstraintTest.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using LazyEntityGraph.Core.Constraints;
-using Ploeh.AutoFixture;
+using AutoFixture;
 using Xunit;
 
 namespace LazyEntityGraph.Tests.Integration

--- a/src/LazyEntityGraph.Tests/Integration/IntegrationTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/IntegrationTest.cs
@@ -2,7 +2,7 @@
 using LazyEntityGraph.AutoFixture;
 using LazyEntityGraph.Core;
 using LazyEntityGraph.Core.Constraints;
-using Ploeh.AutoFixture;
+using AutoFixture;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/LazyEntityGraph.Tests/Integration/ManyToManyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ManyToManyConstraintTest.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using LazyEntityGraph.Core;
 using LazyEntityGraph.Core.Constraints;
-using Ploeh.AutoFixture;
+using AutoFixture;
 using System.Linq;
 using Xunit;
 

--- a/src/LazyEntityGraph.Tests/Integration/ManyToOneConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ManyToOneConstraintTest.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using LazyEntityGraph.Core;
 using LazyEntityGraph.Core.Constraints;
-using Ploeh.AutoFixture;
+using AutoFixture;
 using Xunit;
 
 namespace LazyEntityGraph.Tests.Integration

--- a/src/LazyEntityGraph.Tests/Integration/OneToManyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/OneToManyConstraintTest.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using LazyEntityGraph.Core;
 using LazyEntityGraph.Core.Constraints;
-using Ploeh.AutoFixture;
+using AutoFixture;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/LazyEntityGraph.Tests/Integration/OneToOneConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/OneToOneConstraintTest.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using LazyEntityGraph.Core;
 using LazyEntityGraph.Core.Constraints;
-using Ploeh.AutoFixture;
+using AutoFixture;
 using Xunit;
 
 namespace LazyEntityGraph.Tests.Integration

--- a/src/LazyEntityGraph.Tests/LazyEntityGraph.Tests.csproj
+++ b/src/LazyEntityGraph.Tests/LazyEntityGraph.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +13,8 @@
     <AssemblyName>LazyEntityGraph.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,51 +34,44 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.3.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.3.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.2.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.2\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Fare, Version=2.1.0.0, Culture=neutral, PublicKeyToken=ea68d375bf33a7c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fare.2.1.1\lib\net35\Fare.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.2\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.43.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.43.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.43.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.43.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=5.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.5.3.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -108,7 +105,22 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/LazyEntityGraph.Tests/packages.config
+++ b/src/LazyEntityGraph.Tests/packages.config
@@ -1,13 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.43.0" targetFramework="net452" />
-  <package id="AutoFixture.Xunit2" version="3.43.0" targetFramework="net452" />
-  <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
-  <package id="FluentAssertions" version="4.2.2" targetFramework="net452" />
-  <package id="xunit" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="AutoFixture" version="4.3.0" targetFramework="net452" />
+  <package id="AutoFixture.Xunit2" version="4.3.0" targetFramework="net452" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
+  <package id="Fare" version="2.1.1" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="xunit" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.8.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
@alexfoxgill The namespace changed for AutoFixture 4 since Mark Seemann is no longer maintaining it. Let me know if you'd like this broken out differently and I'd be happy to resubmit.