### PR TITLE
Fix derived entities

### DIFF
--- a/src/LazyEntityGraph.Core/Constraints/ForeignKeyConstraint.cs
+++ b/src/LazyEntityGraph.Core/Constraints/ForeignKeyConstraint.cs
@@ -63,5 +63,10 @@ namespace LazyEntityGraph.Core.Constraints
             }
         }
         #endregion
+
+        public override string ToString()
+        {
+            return $"{typeof(T).Name}.{PropInfo.Name}({_foreignKeyProp.Name}) references {typeof(TProp).Name}.{_idProp.Name}";
+        }
     }
 }

--- a/src/LazyEntityGraph.Core/Constraints/ManyToManyPropertyConstraint.cs
+++ b/src/LazyEntityGraph.Core/Constraints/ManyToManyPropertyConstraint.cs
@@ -67,6 +67,12 @@ namespace LazyEntityGraph.Core.Constraints
                        (PropInfo != null ? PropInfo.GetHashCode() : 0);
             }
         }
+
         #endregion
+
+        public override string ToString()
+        {
+            return $"{typeof(THost).Name}.{PropInfo.Name} *..* {typeof(TProperty).Name}.{_inverse.Name}";
+        }
     }
 }

--- a/src/LazyEntityGraph.Core/Constraints/ManyToOnePropertyConstraint.cs
+++ b/src/LazyEntityGraph.Core/Constraints/ManyToOnePropertyConstraint.cs
@@ -59,5 +59,10 @@ namespace LazyEntityGraph.Core.Constraints
             }
         }
         #endregion
+
+        public override string ToString()
+        {
+            return $"{typeof(THost).Name}.{PropInfo.Name} *..1 {typeof(TProperty).Name}.{_inverse.Name}";
+        }
     }
 }

--- a/src/LazyEntityGraph.Core/Constraints/OneToManyPropertyConstraint.cs
+++ b/src/LazyEntityGraph.Core/Constraints/OneToManyPropertyConstraint.cs
@@ -65,5 +65,9 @@ namespace LazyEntityGraph.Core.Constraints
             }
         }
         #endregion
+        public override string ToString()
+        {
+            return $"{typeof(THost).Name}.{PropInfo.Name} 1..* {typeof(TProperty).Name}.{_inverse.Name}";
+        }
     }
 }

--- a/src/LazyEntityGraph.Core/Constraints/OneToOnePropertyConstraint.cs
+++ b/src/LazyEntityGraph.Core/Constraints/OneToOnePropertyConstraint.cs
@@ -57,5 +57,10 @@ namespace LazyEntityGraph.Core.Constraints
             }
         }
         #endregion
+
+        public override string ToString()
+        {
+            return $"{typeof(THost).Name}.{PropInfo.Name} 1..1 {typeof(TProperty).Name}.{_inverse.Name}";
+        }
     }
 }

--- a/src/LazyEntityGraph.Core/IProperty.cs
+++ b/src/LazyEntityGraph.Core/IProperty.cs
@@ -2,14 +2,14 @@
 
 namespace LazyEntityGraph.Core
 {
-    public interface IProperty<T>
+    public interface IProperty<out T>
     {
         PropertyInfo PropInfo { get; }
         void Set(object value);
         object Get();
     }
 
-    public interface IProperty<T, TProperty> : IProperty<T>
+    public interface IProperty<out T, TProperty> : IProperty<T>
     {
         void Set(TProperty value);
         new TProperty Get();

--- a/src/LazyEntityGraph.Core/PropertyFactory.cs
+++ b/src/LazyEntityGraph.Core/PropertyFactory.cs
@@ -1,4 +1,5 @@
 using LazyEntityGraph.Core.Constraints;
+using LazyEntityGraph.Core.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +37,7 @@ namespace LazyEntityGraph.Core
                 ? typeof(CollectionProperty<,>).MakeGenericType(typeof(T), pi.PropertyType.GetGenericArguments()[0])
                 : typeof(Property<,>).MakeGenericType(typeof(T), pi.PropertyType);
 
-            var constraints = _constraints.Where(c => c.PropInfo == pi);
+            var constraints = _constraints.Where(c => c.PropInfo.PropertyEquals(pi));
 
             return (IProperty<T>)Activator.CreateInstance(t, host, pi, _instanceCreator, constraints);
         }

--- a/src/LazyEntityGraph.EntityFramework/ModelMetadataGenerator.cs
+++ b/src/LazyEntityGraph.EntityFramework/ModelMetadataGenerator.cs
@@ -30,7 +30,7 @@ namespace LazyEntityGraph.EntityFramework
 
             var types = entityTypes.Select(x => x.GetClrType());
             var constraints = entityTypes
-                .SelectMany(et => et.NavigationProperties)
+                .SelectMany(et => et.DeclaredNavigationProperties)
                 .GroupBy(np => np.RelationshipType)
                 .Select(r => r.ToList())
                 .Where(r => r.Count == 2)

--- a/src/LazyEntityGraph.Tests/EntityFramework/BlogModel.cs
+++ b/src/LazyEntityGraph.Tests/EntityFramework/BlogModel.cs
@@ -40,6 +40,11 @@ namespace LazyEntityGraph.Tests.EntityFramework
         public virtual ICollection<Category> Categories { get; set; }
     }
 
+    public class Story : Post
+    {
+        
+    }
+
     public class Tag : Entity
     {
         public string TagName { get; set; }

--- a/src/LazyEntityGraph.Tests/EntityFramework/ModelMetadataGeneratorTests.cs
+++ b/src/LazyEntityGraph.Tests/EntityFramework/ModelMetadataGeneratorTests.cs
@@ -20,7 +20,7 @@ namespace LazyEntityGraph.Tests.EntityFramework
             // arrange
             var expected = new[]
             {
-                typeof (Post), typeof (User), typeof (Tag), typeof (ContactDetails), typeof (Category)
+                typeof (Post), typeof (User), typeof (Tag), typeof (ContactDetails), typeof (Category), typeof(Story)
             };
 
             // act

--- a/src/LazyEntityGraph.Tests/Integration/EndToEndTests.cs
+++ b/src/LazyEntityGraph.Tests/Integration/EndToEndTests.cs
@@ -39,5 +39,12 @@ namespace LazyEntityGraph.Tests.Integration
             foreach (var post in user.Posts)
                 post.PosterId.Should().Be(user.Id);
         }
+
+        [Theory, BlogModelData]
+        public void ForeignKeyPropertyOnDerivedOneToMany(Story story)
+        {
+            // assert
+            story.Poster.Id.Should().Be(story.PosterId);
+        }
     }
 }

--- a/src/LazyEntityGraph.Tests/Integration/FooBar.cs
+++ b/src/LazyEntityGraph.Tests/Integration/FooBar.cs
@@ -26,4 +26,8 @@ namespace LazyEntityGraph.Tests.Integration
         public virtual Foo Foo { get; set; }
         public virtual ICollection<Foo> Foos { get; set; }
     }
+
+    public class Faz : Foo
+    {
+    }
 }

--- a/src/LazyEntityGraph.Tests/Integration/ForeignKeyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ForeignKeyConstraintTest.cs
@@ -36,6 +36,34 @@ namespace LazyEntityGraph.Tests.Integration
         }
 
         [Fact]
+        public void SetsDerivedPropertyToGeneratedProxyProperty()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(new ForeignKeyConstraint<Foo, Bar, int>(f => f.Bar, f => f.BarId, b => b.Id));
+            var foo = fixture.Create<Faz>();
+
+            // act
+            var bar = foo.Bar;
+
+            // assert
+            foo.BarId.Should().Be(bar.Id);
+        }
+        [Fact]
+        public void SetsDerivedPropertyToPOCOProperty()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(new ForeignKeyConstraint<Foo, Bar, int>(f => f.Bar, f => f.BarId, b => b.Id));
+            var foo = fixture.Create<Faz>();
+            var bar = new Bar() { Id = fixture.Create<int>() };
+
+            // act
+            foo.Bar = bar;
+
+            // assert
+            foo.BarId.Should().Be(bar.Id);
+        }
+
+        [Fact]
         public void ConstraintsAreEqualWhenPropertiesAreEqual()
         {
             // arrange

--- a/src/LazyEntityGraph.Tests/Integration/IntegrationTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/IntegrationTest.cs
@@ -14,7 +14,7 @@ namespace LazyEntityGraph.Tests.Integration
         {
             var customization = new LazyEntityGraphCustomization(
                 new ModelMetadata(
-                    new[] { typeof(Foo), typeof(Bar) },
+                    new[] { typeof(Foo), typeof(Bar), typeof(Faz) },
                     constraints));
 
             var fixture = new Fixture();

--- a/src/LazyEntityGraph.Tests/Integration/ManyToManyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ManyToManyConstraintTest.cs
@@ -25,6 +25,21 @@ namespace LazyEntityGraph.Tests.Integration
         }
 
         [Fact]
+        public void AddsItemToDerivedGeneratedCollection()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(new ManyToManyPropertyConstraint<Foo, Bar>(f => f.Bars, b => b.Foos));
+            var foo = fixture.Create<Faz>();
+
+            // act
+            var bars = foo.Bars;
+
+            // assert
+            foreach (var bar in bars)
+                bar.Foos.Should().Contain(foo);
+        }
+
+        [Fact]
         public void RemovesItemFromCollection()
         {
             // arrange

--- a/src/LazyEntityGraph.Tests/Integration/ManyToOneConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ManyToOneConstraintTest.cs
@@ -23,6 +23,20 @@ namespace LazyEntityGraph.Tests.Integration
         }
 
         [Fact]
+        public void AddsDerivedItemToGeneratedCollection()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(new ManyToOnePropertyConstraint<Foo, Bar>(f => f.Bar, b => b.Foos));
+            var foo = fixture.Create<Faz>();
+
+            // act
+            var bar = foo.Bar;
+
+            // assert
+            bar.Foos.Should().Contain(foo);
+        }
+
+        [Fact]
         public void AddsItemToPOCOCollection()
         {
             // arrange 

--- a/src/LazyEntityGraph.Tests/Integration/OneToManyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/OneToManyConstraintTest.cs
@@ -25,6 +25,21 @@ namespace LazyEntityGraph.Tests.Integration
         }
 
         [Fact]
+        public void SetsInversePropertyOnDerivedGeneratedCollection()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(new OneToManyPropertyConstraint<Foo, Bar>(f => f.Bars, b => b.Foo));
+            var foo = fixture.Create<Faz>();
+
+            // act
+            var bars = foo.Bars;
+
+            // assert
+            foreach (var bar in bars)
+                bar.Foo.Should().BeSameAs(foo);
+        }
+
+        [Fact]
         public void SetsInversePropertyOnExternalCollection()
         {
             // arrange

--- a/src/LazyEntityGraph.Tests/Integration/OneToOneConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/OneToOneConstraintTest.cs
@@ -23,6 +23,20 @@ namespace LazyEntityGraph.Tests.Integration
         }
 
         [Fact]
+        public void SetsInversePropertyOnDerivedGeneratedProxy()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(new OneToOnePropertyConstraint<Foo, Bar>(f => f.Bar, b => b.Foo));
+            var foo = fixture.Create<Faz>();
+
+            // act
+            var bar = foo.Bar;
+
+            // assert
+            bar.Foo.Should().BeSameAs(foo);
+        }
+
+        [Fact]
         public void SetsInversePropertyOnExternalProxy()
         {
             // arrange


### PR DESCRIPTION
Derived entities failed populate properties from their base class. They would either be null, or have mismatched IDs.

This PR:
* Changes the way PropertyInfo is compared, so derived classes match.
* Make T covariant in IProperty and IPropertyAccessor so that casts work
* Uses EntityFramework's DeclaredNavigationProperties so we don't get duplicates
* Adds tests for the above.
