### PR TITLE
netstandard2.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,9 @@ build:
   publish_nuget: true
   publish_nuget_symbols: true
   verbosity: minimal
-test:
-  assemblies:
-    only:
-    - '**\LazyEntityGraph*Tests.dll'
+test_script:
+  - dotnet test 'src\LazyEntityGraph.Tests'
+  - dotnet test 'src\LazyEntityGraph.EntityFramework.Tests'
 deploy:
 - provider: NuGet
   api_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ build:
   publish_nuget_symbols: true
   verbosity: minimal
 test_script:
-  - dotnet test 'src\LazyEntityGraph.Tests\LazyEntityGraph.Tests.csproj'
-  - dotnet test 'src\LazyEntityGraph.EntityFramework.Tests\LazyEntityGraph.EntityFramework.Tests.csproj'
+  - dotnet test .\src\LazyEntityGraph.Tests\LazyEntityGraph.Tests.csproj
+  - dotnet test .\src\LazyEntityGraph.EntityFramework.Tests\LazyEntityGraph.EntityFramework.Tests.csproj
 deploy:
 - provider: NuGet
   api_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ build:
   publish_nuget_symbols: true
   verbosity: minimal
 test_script:
-  - dotnet test 'src\LazyEntityGraph.Tests'
-  - dotnet test 'src\LazyEntityGraph.EntityFramework.Tests'
+  - dotnet test 'src\LazyEntityGraph.Tests\LazyEntityGraph.Tests.csproj'
+  - dotnet test 'src\LazyEntityGraph.EntityFramework.Tests\LazyEntityGraph.EntityFramework.Tests.csproj'
 deploy:
 - provider: NuGet
   api_key:

--- a/src/LazyEntityGraph.AutoFixture/LazyEntityGraph.AutoFixture.csproj
+++ b/src/LazyEntityGraph.AutoFixture/LazyEntityGraph.AutoFixture.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LazyEntityGraph.AutoFixture</PackageId>
     <Version>1.0.0</Version>

--- a/src/LazyEntityGraph.Core/LazyEntityGraph.Core.csproj
+++ b/src/LazyEntityGraph.Core/LazyEntityGraph.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LazyEntityGraph</PackageId>
     <Version>1.0.0</Version>
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/dbroudy/LazyEntityGraph</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="[4,5)" />
+    <PackageReference Include="Castle.Core" Version="[4.1.0,5)" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/LazyEntityGraph.Core/LazyEntityGraph.Core.csproj
+++ b/src/LazyEntityGraph.Core/LazyEntityGraph.Core.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/dbroudy/LazyEntityGraph</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="[4.1.0,5)" />
+    <PackageReference Include="Castle.Core" Version="[4.2.0,5)" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/LazyEntityGraph.EntityFramework.Tests/BlogModel.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests/BlogModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Data.Entity;
 
-namespace LazyEntityGraph.Tests.EntityFramework
+namespace LazyEntityGraph.EntityFramework.Tests
 {
     public class Entity
     {

--- a/src/LazyEntityGraph.EntityFramework.Tests/EndToEndTests.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests/EndToEndTests.cs
@@ -1,13 +1,11 @@
 ﻿using FluentAssertions;
 using LazyEntityGraph.AutoFixture;
-using LazyEntityGraph.EntityFramework;
-using LazyEntityGraph.Tests.EntityFramework;
 using AutoFixture;
 using AutoFixture.Xunit2;
 using Xunit;
 using System;
 
-namespace LazyEntityGraph.Tests.Integration
+namespace LazyEntityGraph.EntityFramework.Tests
 {
     public class BlogModelDataAttribute : AutoDataAttribute
     {

--- a/src/LazyEntityGraph.EntityFramework.Tests/LazyEntityGraph.EntityFramework.Tests.csproj
+++ b/src/LazyEntityGraph.EntityFramework.Tests/LazyEntityGraph.EntityFramework.Tests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="[4.2.0,5)" />
     <PackageReference Include="AutoFixture.Xunit2" Version="[4.2.0,5)" />
+    <PackageReference Include="EntityFramework" Version="[6.1.3,7)" />
     <PackageReference Include="FluentAssertions" Version="[5.4.1,6)" />
     <PackageReference Include="xunit" Version="[2.3.1,3)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1,3)" />
@@ -15,5 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\LazyEntityGraph.AutoFixture\LazyEntityGraph.AutoFixture.csproj" />
     <ProjectReference Include="..\LazyEntityGraph.Core\LazyEntityGraph.Core.csproj" />
+    <ProjectReference Include="..\LazyEntityGraph.EntityFramework\LazyEntityGraph.EntityFramework.csproj" />
   </ItemGroup>
 </Project>
+

--- a/src/LazyEntityGraph.EntityFramework.Tests/LazyEntityGraph.EntityFramework.Tests.csproj
+++ b/src/LazyEntityGraph.EntityFramework.Tests/LazyEntityGraph.EntityFramework.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="EntityFramework" Version="[6.1.3,7)" />
     <PackageReference Include="FluentAssertions" Version="[5.4.1,6)" />
     <PackageReference Include="xunit" Version="[2.3.1,3)" />
+    <PackageReference Include="xunit.runner.reporters" Version="[2.3.1,3)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1,3)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/LazyEntityGraph.EntityFramework.Tests/ModelMetadataGeneratorTests.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests/ModelMetadataGeneratorTests.cs
@@ -5,7 +5,7 @@ using LazyEntityGraph.EntityFramework;
 using System.Collections;
 using Xunit;
 
-namespace LazyEntityGraph.Tests.EntityFramework
+namespace LazyEntityGraph.EntityFramework.Tests
 {
     public class ModelMetadataGeneratorTests
     {

--- a/src/LazyEntityGraph.Tests/LazyEntityGraph.Tests.csproj
+++ b/src/LazyEntityGraph.Tests/LazyEntityGraph.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="[4.2.0,5)" />
     <PackageReference Include="FluentAssertions" Version="[5.4.1,6)" />
     <PackageReference Include="xunit" Version="[2.3.1,3)" />
+    <PackageReference Include="xunit.runner.reporters" Version="[2.3.1,3)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1,3)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/LazyEntityGraph.sln
+++ b/src/LazyEntityGraph.sln
@@ -1,13 +1,17 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LazyEntityGraph.Core", "LazyEntityGraph.Core\LazyEntityGraph.Core.csproj", "{22FF6382-B4A4-4259-91B4-7554D0BD050D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LazyEntityGraph.Core", "LazyEntityGraph.Core\LazyEntityGraph.Core.csproj", "{22FF6382-B4A4-4259-91B4-7554D0BD050D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LazyEntityGraph.AutoFixture", "LazyEntityGraph.AutoFixture\LazyEntityGraph.AutoFixture.csproj", "{A2560FE5-D76D-49CD-9D9F-E34B6235B0F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LazyEntityGraph.AutoFixture", "LazyEntityGraph.AutoFixture\LazyEntityGraph.AutoFixture.csproj", "{A2560FE5-D76D-49CD-9D9F-E34B6235B0F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LazyEntityGraph.Tests", "LazyEntityGraph.Tests\LazyEntityGraph.Tests.csproj", "{1DEB42E2-18A4-4F48-9443-F20535BCF80F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LazyEntityGraph.Tests", "LazyEntityGraph.Tests\LazyEntityGraph.Tests.csproj", "{1DEB42E2-18A4-4F48-9443-F20535BCF80F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LazyEntityGraph.EntityFramework", "LazyEntityGraph.EntityFramework\LazyEntityGraph.EntityFramework.csproj", "{35DE7C5D-017F-4250-9179-B02D9621FC94}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LazyEntityGraph.EntityFramework", "LazyEntityGraph.EntityFramework\LazyEntityGraph.EntityFramework.csproj", "{35DE7C5D-017F-4250-9179-B02D9621FC94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LazyEntityGraph.EntityFramework.Tests", "LazyEntityGraph.EntityFramework.Tests\LazyEntityGraph.EntityFramework.Tests.csproj", "{A0DE117F-2028-4E06-9584-310A7A23F0CA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,8 +35,15 @@ Global
 		{35DE7C5D-017F-4250-9179-B02D9621FC94}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35DE7C5D-017F-4250-9179-B02D9621FC94}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35DE7C5D-017F-4250-9179-B02D9621FC94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0DE117F-2028-4E06-9584-310A7A23F0CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0DE117F-2028-4E06-9584-310A7A23F0CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0DE117F-2028-4E06-9584-310A7A23F0CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0DE117F-2028-4E06-9584-310A7A23F0CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {625DDF37-13AB-427E-A59F-58AECBFABC26}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add netstandard 2.0 support. Split EF6 unit tests to distinct project and run core unit tests on both frameworks.

Should satisfy issue #8 and PR #5 