### PR TITLE
Adds support for one sided navigation properties.

### DIFF
--- a/src/LazyEntityGraph.EntityFramework.Tests.Edmx/BlogModel.edmx
+++ b/src/LazyEntityGraph.EntityFramework.Tests.Edmx/BlogModel.edmx
@@ -1,369 +1,407 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx Version="3.0" xmlns:edmx="http://schemas.microsoft.com/ado/2009/11/edmx">
-  <!-- EF Runtime content -->
-  <edmx:Runtime>
-    <!-- SSDL content -->
-    <edmx:StorageModels>
-    <Schema Namespace="BlogModel.Store" Alias="Self" Provider="System.Data.SqlClient" ProviderManifestToken="2012" xmlns:store="http://schemas.microsoft.com/ado/2007/12/edm/EntityStoreSchemaGenerator" xmlns="http://schemas.microsoft.com/ado/2009/11/edm/ssdl">
-  <EntityContainer Name="BlogModelStoreContainer">
-    <EntitySet Name="Posts" EntityType="BlogModel.Store.Posts" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="Users" EntityType="BlogModel.Store.Users" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="Tags" EntityType="BlogModel.Store.Tags" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="ContactDetails" EntityType="BlogModel.Store.ContactDetails" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="Categories" EntityType="BlogModel.Store.Categories" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="Posts_Story" EntityType="BlogModel.Store.Posts_Story" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="PostTag" EntityType="BlogModel.Store.PostTag" store:Type="Tables" Schema="dbo" />
-    <EntitySet Name="PostCategory" EntityType="BlogModel.Store.PostCategory" store:Type="Tables" Schema="dbo" />
-    <AssociationSet Name="FK_PostTag_Post" Association="BlogModel.Store.FK_PostTag_Post">
-      <End Role="Post" EntitySet="Posts" />
-      <End Role="PostTag" EntitySet="PostTag" />
-    </AssociationSet>
-    <AssociationSet Name="FK_PostTag_Tag" Association="BlogModel.Store.FK_PostTag_Tag">
-      <End Role="Tag" EntitySet="Tags" />
-      <End Role="PostTag" EntitySet="PostTag" />
-    </AssociationSet>
-    <AssociationSet Name="PostUser" Association="BlogModel.Store.PostUser">
-      <End Role="Post" EntitySet="Posts" />
-      <End Role="User" EntitySet="Users" />
-    </AssociationSet>
-    <AssociationSet Name="UserContactDetails" Association="BlogModel.Store.UserContactDetails">
-      <End Role="User" EntitySet="Users" />
-      <End Role="ContactDetails" EntitySet="ContactDetails" />
-    </AssociationSet>
-    <AssociationSet Name="FK_PostCategory_Post" Association="BlogModel.Store.FK_PostCategory_Post">
-      <End Role="Post" EntitySet="Posts" />
-      <End Role="PostCategory" EntitySet="PostCategory" />
-    </AssociationSet>
-    <AssociationSet Name="FK_PostCategory_Category" Association="BlogModel.Store.FK_PostCategory_Category">
-      <End Role="Category" EntitySet="Categories" />
-      <End Role="PostCategory" EntitySet="PostCategory" />
-    </AssociationSet>
-    <AssociationSet Name="FK_Story_inherits_Post" Association="BlogModel.Store.FK_Story_inherits_Post">
-      <End Role="Post" EntitySet="Posts" />
-      <End Role="Story" EntitySet="Posts_Story" />
-    </AssociationSet>
-  </EntityContainer>
-  <EntityType Name="Posts">
-    <Key>
-      <PropertyRef Name="Id" />
-    </Key>
-    <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
-    <Property Name="PosterId" Type="int" Nullable="false" />
-  </EntityType>
-  <EntityType Name="Users">
-    <Key>
-      <PropertyRef Name="Id" />
-    </Key>
-    <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
-  </EntityType>
-  <EntityType Name="Tags">
-    <Key>
-      <PropertyRef Name="Id" />
-    </Key>
-    <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
-  </EntityType>
-  <EntityType Name="ContactDetails">
-    <Key>
-      <PropertyRef Name="UserId" />
-    </Key>
-    <Property Name="UserId" Type="int" Nullable="false" />
-  </EntityType>
-  <EntityType Name="Categories">
-    <Key>
-      <PropertyRef Name="Id" />
-    </Key>
-    <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
-  </EntityType>
-  <EntityType Name="Posts_Story">
-    <Key>
-      <PropertyRef Name="Id" />
-    </Key>
-    <Property Name="Id" Type="int" Nullable="false" />
-  </EntityType>
-  <EntityType Name="PostTag">
-    <Key>
-      <PropertyRef Name="Posts_Id" />
-      <PropertyRef Name="Tags_Id" />
-    </Key>
-    <Property Name="Posts_Id" Type="int" Nullable="false" />
-    <Property Name="Tags_Id" Type="int" Nullable="false" />
-  </EntityType>
-  <EntityType Name="PostCategory">
-    <Key>
-      <PropertyRef Name="PostCategory_Category_Id" />
-      <PropertyRef Name="Categories_Id" />
-    </Key>
-    <Property Name="PostCategory_Category_Id" Type="int" Nullable="false" />
-    <Property Name="Categories_Id" Type="int" Nullable="false" />
-  </EntityType>
-  <Association Name="PostUser">
-    <End Role="Post" Type="BlogModel.Store.Posts" Multiplicity="*" />
-    <End Role="User" Type="BlogModel.Store.Users" Multiplicity="1" />
-    <ReferentialConstraint>
-      <Principal Role="User">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="Post">
-        <PropertyRef Name="PosterId" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-  <Association Name="UserContactDetails">
-    <End Role="User" Type="BlogModel.Store.Users" Multiplicity="1" />
-    <End Role="ContactDetails" Type="BlogModel.Store.ContactDetails" Multiplicity="0..1" />
-    <ReferentialConstraint>
-      <Principal Role="User">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="ContactDetails">
-        <PropertyRef Name="UserId" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-  <Association Name="FK_PostTag_Post">
-    <End Role="Post" Type="BlogModel.Store.Posts" Multiplicity="1" />
-    <End Role="PostTag" Type="BlogModel.Store.PostTag" Multiplicity="*" />
-    <ReferentialConstraint>
-      <Principal Role="Post">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="PostTag">
-        <PropertyRef Name="Posts_Id" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-  <Association Name="FK_PostTag_Tag">
-    <End Role="PostTag" Type="BlogModel.Store.PostTag" Multiplicity="*" />
-    <End Role="Tag" Type="BlogModel.Store.Tags" Multiplicity="1" />
-    <ReferentialConstraint>
-      <Principal Role="Tag">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="PostTag">
-        <PropertyRef Name="Tags_Id" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-  <Association Name="FK_PostCategory_Post">
-    <End Role="Post" Type="BlogModel.Store.Posts" Multiplicity="1" />
-    <End Role="PostCategory" Type="BlogModel.Store.PostCategory" Multiplicity="*" />
-    <ReferentialConstraint>
-      <Principal Role="Post">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="PostCategory">
-        <PropertyRef Name="PostCategory_Category_Id" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-  <Association Name="FK_PostCategory_Category">
-    <End Role="PostCategory" Type="BlogModel.Store.PostCategory" Multiplicity="*" />
-    <End Role="Category" Type="BlogModel.Store.Categories" Multiplicity="1" />
-    <ReferentialConstraint>
-      <Principal Role="Category">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="PostCategory">
-        <PropertyRef Name="Categories_Id" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-  <Association Name="FK_Story_inherits_Post">
-    <End Role="Post" Type="BlogModel.Store.Posts" Multiplicity="1">
-      <OnDelete Action="Cascade" />
-    </End>
-    <End Role="Story" Type="BlogModel.Store.Posts_Story" Multiplicity="0..1" />
-    <ReferentialConstraint>
-      <Principal Role="Post">
-        <PropertyRef Name="Id" />
-      </Principal>
-      <Dependent Role="Story">
-        <PropertyRef Name="Id" />
-      </Dependent>
-    </ReferentialConstraint>
-  </Association>
-</Schema></edmx:StorageModels>
-    <!-- CSDL content -->
-    <edmx:ConceptualModels>
-      <Schema xmlns="http://schemas.microsoft.com/ado/2009/11/edm" xmlns:cg="http://schemas.microsoft.com/ado/2006/04/codegeneration" xmlns:store="http://schemas.microsoft.com/ado/2007/12/edm/EntityStoreSchemaGenerator" Namespace="LazyEntityGraph.EntityFramework.Tests.Edmx" Alias="Self" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" annotation:UseStrongSpatialTypes="false">
-        <EntityContainer Name="BlogModelContainer" annotation:LazyLoadingEnabled="true">
-          <EntitySet Name="Posts" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" />
-          <EntitySet Name="Users" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.User" />
-          <EntitySet Name="Tags" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Tag" />
-          <EntitySet Name="ContactDetails" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.ContactDetails" />
-          <EntitySet Name="Categories" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Category" />
-          <AssociationSet Name="PostTag" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag">
-            <End Role="Post" EntitySet="Posts" />
-            <End Role="Tag" EntitySet="Tags" />
-          </AssociationSet>
-          <AssociationSet Name="PostUser" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostUser">
-            <End Role="Post" EntitySet="Posts" />
-            <End Role="User" EntitySet="Users" />
-          </AssociationSet>
-          <AssociationSet Name="UserContactDetails" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails">
-            <End Role="User" EntitySet="Users" />
-            <End Role="ContactDetails" EntitySet="ContactDetails" />
-          </AssociationSet>
-          <AssociationSet Name="PostCategory" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory">
-            <End Role="Post" EntitySet="Posts" />
-            <End Role="Category" EntitySet="Categories" />
-          </AssociationSet>
-        </EntityContainer>
-        <EntityType Name="Post">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-          <NavigationProperty Name="Tags" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag" FromRole="Post" ToRole="Tag" />
-          <NavigationProperty Name="Poster" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostUser" FromRole="Post" ToRole="User" />
-          <NavigationProperty Name="Categories" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory" FromRole="Post" ToRole="Category" />
-          <Property Name="PosterId" Type="Int32" Nullable="false" />
-        </EntityType>
-        <EntityType Name="User">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-          <NavigationProperty Name="Posts" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostUser" FromRole="User" ToRole="Post" />
-          <NavigationProperty Name="ContactDetails" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails" FromRole="User" ToRole="ContactDetails" />
-        </EntityType>
-        <EntityType Name="Tag">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-          <NavigationProperty Name="Posts" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag" FromRole="Tag" ToRole="Post" />
-        </EntityType>
-        <EntityType Name="ContactDetails">
-          <Key>
-            <PropertyRef Name="UserId" />
-          </Key>
-          <Property Name="UserId" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="None" />
-          <NavigationProperty Name="User" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails" FromRole="ContactDetails" ToRole="User" />
-        </EntityType>
-        <EntityType Name="Category">
-          <Key>
-            <PropertyRef Name="Id" />
-          </Key>
-          <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
-        </EntityType>
-        <EntityType Name="Story" BaseType="LazyEntityGraph.EntityFramework.Tests.Edmx.Post">
-        </EntityType>
-        <Association Name="PostTag">
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" Role="Post" Multiplicity="*" />
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Tag" Role="Tag" Multiplicity="*" />
-        </Association>
-        <Association Name="PostUser">
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" Role="Post" Multiplicity="*" />
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.User" Role="User" Multiplicity="1" />
-          <ReferentialConstraint>
-            <Principal Role="User">
-              <PropertyRef Name="Id" />
-            </Principal>
-            <Dependent Role="Post">
-              <PropertyRef Name="PosterId" />
-            </Dependent>
-          </ReferentialConstraint>
-        </Association>
-        <Association Name="UserContactDetails">
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.User" Role="User" Multiplicity="1" />
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.ContactDetails" Role="ContactDetails" Multiplicity="1" />
-          <ReferentialConstraint>
-            <Principal Role="User">
-              <PropertyRef Name="Id" />
-            </Principal>
-            <Dependent Role="ContactDetails">
-              <PropertyRef Name="UserId" />
-            </Dependent>
-          </ReferentialConstraint>
-        </Association>
-        <Association Name="PostCategory">
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" Role="Post" Multiplicity="*" />
-          <End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Category" Role="Category" Multiplicity="*" />
-        </Association>
-      </Schema>
-    </edmx:ConceptualModels>
-    <!-- C-S mapping content -->
-    <edmx:Mappings>
-    <Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
-  <EntityContainerMapping StorageEntityContainer="BlogModelStoreContainer" CdmEntityContainer="BlogModelContainer">
-    <EntitySetMapping Name="Posts">
-      <EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Post)">
-        <MappingFragment StoreEntitySet="Posts">
-          <ScalarProperty Name="Id" ColumnName="Id" />
-          <ScalarProperty Name="PosterId" ColumnName="PosterId" />
-        </MappingFragment>
-      </EntityTypeMapping>
-      <EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Story)">
-        <MappingFragment StoreEntitySet="Posts_Story">
-          <ScalarProperty Name="Id" ColumnName="Id" />
-        </MappingFragment>
-      </EntityTypeMapping>
-    </EntitySetMapping>
-    <EntitySetMapping Name="Users">
-      <EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.User)">
-        <MappingFragment StoreEntitySet="Users">
-          <ScalarProperty Name="Id" ColumnName="Id" />
-        </MappingFragment>
-      </EntityTypeMapping>
-    </EntitySetMapping>
-    <EntitySetMapping Name="Tags">
-      <EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Tag)">
-        <MappingFragment StoreEntitySet="Tags">
-          <ScalarProperty Name="Id" ColumnName="Id" />
-        </MappingFragment>
-      </EntityTypeMapping>
-    </EntitySetMapping>
-    <EntitySetMapping Name="ContactDetails">
-      <EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.ContactDetails)">
-        <MappingFragment StoreEntitySet="ContactDetails">
-          <ScalarProperty Name="UserId" ColumnName="UserId" />
-        </MappingFragment>
-      </EntityTypeMapping>
-    </EntitySetMapping>
-    <EntitySetMapping Name="Categories">
-      <EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Category)">
-        <MappingFragment StoreEntitySet="Categories">
-          <ScalarProperty Name="Id" ColumnName="Id" />
-        </MappingFragment>
-      </EntityTypeMapping>
-    </EntitySetMapping>
-    <AssociationSetMapping Name="PostTag" TypeName="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag" StoreEntitySet="PostTag">
-      <EndProperty Name="Post">
-        <ScalarProperty Name="Id" ColumnName="Posts_Id" />
-      </EndProperty>
-      <EndProperty Name="Tag">
-        <ScalarProperty Name="Id" ColumnName="Tags_Id" />
-      </EndProperty>
-    </AssociationSetMapping>
-    <AssociationSetMapping Name="PostCategory" TypeName="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory" StoreEntitySet="PostCategory">
-      <EndProperty Name="Post">
-        <ScalarProperty Name="Id" ColumnName="PostCategory_Category_Id" />
-      </EndProperty>
-      <EndProperty Name="Category">
-        <ScalarProperty Name="Id" ColumnName="Categories_Id" />
-      </EndProperty>
-    </AssociationSetMapping>
-  </EntityContainerMapping>
-</Mapping></edmx:Mappings>
-  </edmx:Runtime>
-  <!-- EF Designer content (DO NOT EDIT MANUALLY BELOW HERE) -->
-  <edmx:Designer xmlns="http://schemas.microsoft.com/ado/2009/11/edmx">
-    <edmx:Connection>
-      <DesignerInfoPropertySet>
-        <DesignerProperty Name="MetadataArtifactProcessing" Value="EmbedInOutputAssembly" />
-      </DesignerInfoPropertySet>
-    </edmx:Connection>
-    <edmx:Options>
-      <DesignerInfoPropertySet>
-        <DesignerProperty Name="ValidateOnBuild" Value="true" />
-        <DesignerProperty Name="EnablePluralization" Value="True" />
-        <DesignerProperty Name="CodeGenerationStrategy" Value="None" />
-        <DesignerProperty Name="UseLegacyProvider" Value="False" />
-      </DesignerInfoPropertySet>
-    </edmx:Options>
-    <!-- Diagram content (shape and connector positions) -->
-    <edmx:Diagrams>
-    </edmx:Diagrams>
-  </edmx:Designer>
+	<!-- EF Runtime content -->
+	<edmx:Runtime>
+		<!-- SSDL content -->
+		<edmx:StorageModels>
+			<Schema Namespace="LazyEntityGraph.EntityFramework.Tests.Edmx.Store" Alias="Self" Provider="System.Data.SqlClient" ProviderManifestToken="2012" xmlns:store="http://schemas.microsoft.com/ado/2007/12/edm/EntityStoreSchemaGenerator" xmlns="http://schemas.microsoft.com/ado/2009/11/edm/ssdl">
+				<EntityContainer Name="LazyEntityGraphEntityFrameworkTestsEdmxStoreContainer">
+					<EntitySet Name="Posts" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="Users" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Users" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="Tags" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Tags" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="ContactDetails" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.ContactDetails" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="Categories" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Categories" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="Posts_Story" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts_Story" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="PostTag" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostTag" store:Type="Tables" Schema="dbo" />
+					<EntitySet Name="PostCategory" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostCategory" store:Type="Tables" Schema="dbo" />
+					<AssociationSet Name="FK_PostTag_Post" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.FK_PostTag_Post">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="PostTag" EntitySet="PostTag" />
+					</AssociationSet>
+					<AssociationSet Name="FK_PostTag_Tag" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.FK_PostTag_Tag">
+						<End Role="Tag" EntitySet="Tags" />
+						<End Role="PostTag" EntitySet="PostTag" />
+					</AssociationSet>
+					<AssociationSet Name="PostUser" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostUser">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="User" EntitySet="Users" />
+					</AssociationSet>
+					<AssociationSet Name="UserContactDetails" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.UserContactDetails">
+						<End Role="User" EntitySet="Users" />
+						<End Role="ContactDetails" EntitySet="ContactDetails" />
+					</AssociationSet>
+					<AssociationSet Name="FK_PostCategory_Post" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.FK_PostCategory_Post">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="PostCategory" EntitySet="PostCategory" />
+					</AssociationSet>
+					<AssociationSet Name="FK_PostCategory_Category" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.FK_PostCategory_Category">
+						<End Role="Category" EntitySet="Categories" />
+						<End Role="PostCategory" EntitySet="PostCategory" />
+					</AssociationSet>
+					<AssociationSet Name="UserDefaultCategory" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.UserDefaultCategory">
+						<End Role="User" EntitySet="Users" />
+						<End Role="Category" EntitySet="Categories" />
+					</AssociationSet>
+					<AssociationSet Name="FK_Story_inherits_Post" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.FK_Story_inherits_Post">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="Story" EntitySet="Posts_Story" />
+					</AssociationSet>
+				</EntityContainer>
+				<EntityType Name="Posts">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+					<Property Name="PosterId" Type="int" Nullable="false" />
+				</EntityType>
+				<EntityType Name="Users">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+					<Property Name="DefaultCategoryId" Type="int" Nullable="false" />
+				</EntityType>
+				<EntityType Name="Tags">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+				</EntityType>
+				<EntityType Name="ContactDetails">
+					<Key>
+						<PropertyRef Name="UserId" />
+					</Key>
+					<Property Name="UserId" Type="int" Nullable="false" />
+				</EntityType>
+				<EntityType Name="Categories">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
+				</EntityType>
+				<EntityType Name="Posts_Story">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="int" Nullable="false" />
+				</EntityType>
+				<EntityType Name="PostTag">
+					<Key>
+						<PropertyRef Name="Posts_Id" />
+						<PropertyRef Name="Tags_Id" />
+					</Key>
+					<Property Name="Posts_Id" Type="int" Nullable="false" />
+					<Property Name="Tags_Id" Type="int" Nullable="false" />
+				</EntityType>
+				<EntityType Name="PostCategory">
+					<Key>
+						<PropertyRef Name="PostCategory_Category_Id" />
+						<PropertyRef Name="Categories_Id" />
+					</Key>
+					<Property Name="PostCategory_Category_Id" Type="int" Nullable="false" />
+					<Property Name="Categories_Id" Type="int" Nullable="false" />
+				</EntityType>
+				<Association Name="PostUser">
+					<End Role="Post" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts" Multiplicity="*" />
+					<End Role="User" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Users" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="User">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="Post">
+							<PropertyRef Name="PosterId" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="UserContactDetails">
+					<End Role="User" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Users" Multiplicity="1" />
+					<End Role="ContactDetails" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.ContactDetails" Multiplicity="0..1" />
+					<ReferentialConstraint>
+						<Principal Role="User">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="ContactDetails">
+							<PropertyRef Name="UserId" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="UserDefaultCategory">
+					<End Role="User" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Users" Multiplicity="*" />
+					<End Role="Category" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Categories" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="Category">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="User">
+							<PropertyRef Name="DefaultCategoryId" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="FK_PostTag_Post">
+					<End Role="Post" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts" Multiplicity="1" />
+					<End Role="PostTag" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostTag" Multiplicity="*" />
+					<ReferentialConstraint>
+						<Principal Role="Post">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="PostTag">
+							<PropertyRef Name="Posts_Id" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="FK_PostTag_Tag">
+					<End Role="PostTag" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostTag" Multiplicity="*" />
+					<End Role="Tag" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Tags" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="Tag">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="PostTag">
+							<PropertyRef Name="Tags_Id" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="FK_PostCategory_Post">
+					<End Role="Post" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts" Multiplicity="1" />
+					<End Role="PostCategory" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostCategory" Multiplicity="*" />
+					<ReferentialConstraint>
+						<Principal Role="Post">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="PostCategory">
+							<PropertyRef Name="PostCategory_Category_Id" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="FK_PostCategory_Category">
+					<End Role="PostCategory" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.PostCategory" Multiplicity="*" />
+					<End Role="Category" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Categories" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="Category">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="PostCategory">
+							<PropertyRef Name="Categories_Id" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="FK_Story_inherits_Post">
+					<End Role="Post" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts" Multiplicity="1">
+						<OnDelete Action="Cascade" />
+					</End>
+					<End Role="Story" Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Store.Posts_Story" Multiplicity="0..1" />
+					<ReferentialConstraint>
+						<Principal Role="Post">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="Story">
+							<PropertyRef Name="Id" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+			</Schema>
+		</edmx:StorageModels>
+		<!-- CSDL content -->
+		<edmx:ConceptualModels>
+			<Schema xmlns="http://schemas.microsoft.com/ado/2009/11/edm" xmlns:cg="http://schemas.microsoft.com/ado/2006/04/codegeneration" xmlns:store="http://schemas.microsoft.com/ado/2007/12/edm/EntityStoreSchemaGenerator" Namespace="LazyEntityGraph.EntityFramework.Tests.Edmx" Alias="Self" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" annotation:UseStrongSpatialTypes="false">
+				<EntityContainer Name="BlogModelContainer" annotation:LazyLoadingEnabled="true">
+					<EntitySet Name="Posts" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" />
+					<EntitySet Name="Users" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.User" />
+					<EntitySet Name="Tags" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Tag" />
+					<EntitySet Name="ContactDetails" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.ContactDetails" />
+					<EntitySet Name="Categories" EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Category" />
+					<AssociationSet Name="PostTag" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="Tag" EntitySet="Tags" />
+					</AssociationSet>
+					<AssociationSet Name="PostUser" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostUser">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="User" EntitySet="Users" />
+					</AssociationSet>
+					<AssociationSet Name="UserContactDetails" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails">
+						<End Role="User" EntitySet="Users" />
+						<End Role="ContactDetails" EntitySet="ContactDetails" />
+					</AssociationSet>
+					<AssociationSet Name="PostCategory" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory">
+						<End Role="Post" EntitySet="Posts" />
+						<End Role="Category" EntitySet="Categories" />
+					</AssociationSet>
+					<AssociationSet Name="UserDefaultCategory" Association="LazyEntityGraph.EntityFramework.Tests.Edmx.UserDefaultCategory">
+						<End Role="User" EntitySet="Users" />
+						<End Role="Category" EntitySet="Categories" />
+					</AssociationSet>
+				</EntityContainer>
+				<EntityType Name="Post">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+					<NavigationProperty Name="Tags" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag" FromRole="Post" ToRole="Tag" />
+					<NavigationProperty Name="Poster" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostUser" FromRole="Post" ToRole="User" />
+					<NavigationProperty Name="Categories" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory" FromRole="Post" ToRole="Category" />
+					<Property Name="PosterId" Type="Int32" Nullable="false" />
+				</EntityType>
+				<EntityType Name="User">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+					<NavigationProperty Name="Posts" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostUser" FromRole="User" ToRole="Post" />
+					<NavigationProperty Name="ContactDetails" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails" FromRole="User" ToRole="ContactDetails" />
+					<NavigationProperty Name="DefaultCategory" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.UserDefaultCategory" FromRole="User" ToRole="Category" />
+					<Property Name="DefaultCategoryId" Type="Int32" Nullable="false" />
+				</EntityType>
+				<EntityType Name="Tag">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+					<NavigationProperty Name="Posts" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag" FromRole="Tag" ToRole="Post" />
+				</EntityType>
+				<EntityType Name="ContactDetails">
+					<Key>
+						<PropertyRef Name="UserId" />
+					</Key>
+					<Property Name="UserId" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="None" />
+					<NavigationProperty Name="User" Relationship="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails" FromRole="ContactDetails" ToRole="User" />
+				</EntityType>
+				<EntityType Name="Category">
+					<Key>
+						<PropertyRef Name="Id" />
+					</Key>
+					<Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
+				</EntityType>
+				<EntityType Name="Story" BaseType="LazyEntityGraph.EntityFramework.Tests.Edmx.Post">
+				</EntityType>
+				<Association Name="PostTag">
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" Role="Post" Multiplicity="*" />
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Tag" Role="Tag" Multiplicity="*" />
+				</Association>
+				<Association Name="PostUser">
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" Role="Post" Multiplicity="*" />
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.User" Role="User" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="User">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="Post">
+							<PropertyRef Name="PosterId" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="UserContactDetails">
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.User" Role="User" Multiplicity="1" />
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.ContactDetails" Role="ContactDetails" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="User">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="ContactDetails">
+							<PropertyRef Name="UserId" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+				<Association Name="PostCategory">
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Post" Role="Post" Multiplicity="*" />
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Category" Role="Category" Multiplicity="*" />
+				</Association>
+				<Association Name="UserDefaultCategory">
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.User" Role="User" Multiplicity="*" />
+					<End Type="LazyEntityGraph.EntityFramework.Tests.Edmx.Category" Role="Category" Multiplicity="1" />
+					<ReferentialConstraint>
+						<Principal Role="Category">
+							<PropertyRef Name="Id" />
+						</Principal>
+						<Dependent Role="User">
+							<PropertyRef Name="DefaultCategoryId" />
+						</Dependent>
+					</ReferentialConstraint>
+				</Association>
+			</Schema>
+		</edmx:ConceptualModels>
+		<!-- C-S mapping content -->
+		<edmx:Mappings>
+			<Mapping Space="C-S" xmlns="http://schemas.microsoft.com/ado/2009/11/mapping/cs">
+				<EntityContainerMapping StorageEntityContainer="LazyEntityGraphEntityFrameworkTestsEdmxStoreContainer" CdmEntityContainer="BlogModelContainer">
+					<EntitySetMapping Name="Posts">
+						<EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Post)">
+							<MappingFragment StoreEntitySet="Posts">
+								<ScalarProperty Name="Id" ColumnName="Id" />
+								<ScalarProperty Name="PosterId" ColumnName="PosterId" />
+							</MappingFragment>
+						</EntityTypeMapping>
+						<EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Story)">
+							<MappingFragment StoreEntitySet="Posts_Story">
+								<ScalarProperty Name="Id" ColumnName="Id" />
+							</MappingFragment>
+						</EntityTypeMapping>
+					</EntitySetMapping>
+					<EntitySetMapping Name="Users">
+						<EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.User)">
+							<MappingFragment StoreEntitySet="Users">
+								<ScalarProperty Name="Id" ColumnName="Id" />
+								<ScalarProperty Name="DefaultCategoryId" ColumnName="DefaultCategoryId" />
+							</MappingFragment>
+						</EntityTypeMapping>
+					</EntitySetMapping>
+					<EntitySetMapping Name="Tags">
+						<EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Tag)">
+							<MappingFragment StoreEntitySet="Tags">
+								<ScalarProperty Name="Id" ColumnName="Id" />
+							</MappingFragment>
+						</EntityTypeMapping>
+					</EntitySetMapping>
+					<EntitySetMapping Name="ContactDetails">
+						<EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.ContactDetails)">
+							<MappingFragment StoreEntitySet="ContactDetails">
+								<ScalarProperty Name="UserId" ColumnName="UserId" />
+							</MappingFragment>
+						</EntityTypeMapping>
+					</EntitySetMapping>
+					<EntitySetMapping Name="Categories">
+						<EntityTypeMapping TypeName="IsTypeOf(LazyEntityGraph.EntityFramework.Tests.Edmx.Category)">
+							<MappingFragment StoreEntitySet="Categories">
+								<ScalarProperty Name="Id" ColumnName="Id" />
+							</MappingFragment>
+						</EntityTypeMapping>
+					</EntitySetMapping>
+					<AssociationSetMapping Name="PostTag" TypeName="LazyEntityGraph.EntityFramework.Tests.Edmx.PostTag" StoreEntitySet="PostTag">
+						<EndProperty Name="Post">
+							<ScalarProperty Name="Id" ColumnName="Posts_Id" />
+						</EndProperty>
+						<EndProperty Name="Tag">
+							<ScalarProperty Name="Id" ColumnName="Tags_Id" />
+						</EndProperty>
+					</AssociationSetMapping>
+					<AssociationSetMapping Name="PostCategory" TypeName="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory" StoreEntitySet="PostCategory">
+						<EndProperty Name="Post">
+							<ScalarProperty Name="Id" ColumnName="PostCategory_Category_Id" />
+						</EndProperty>
+						<EndProperty Name="Category">
+							<ScalarProperty Name="Id" ColumnName="Categories_Id" />
+						</EndProperty>
+					</AssociationSetMapping>
+				</EntityContainerMapping>
+			</Mapping>
+		</edmx:Mappings>
+	</edmx:Runtime>
+	<!-- EF Designer content (DO NOT EDIT MANUALLY BELOW HERE) -->
+	<edmx:Designer xmlns="http://schemas.microsoft.com/ado/2009/11/edmx">
+		<edmx:Connection>
+			<DesignerInfoPropertySet>
+				<DesignerProperty Name="MetadataArtifactProcessing" Value="EmbedInOutputAssembly" />
+			</DesignerInfoPropertySet>
+		</edmx:Connection>
+		<edmx:Options>
+			<DesignerInfoPropertySet>
+				<DesignerProperty Name="ValidateOnBuild" Value="true" />
+				<DesignerProperty Name="EnablePluralization" Value="True" />
+				<DesignerProperty Name="CodeGenerationStrategy" Value="None" />
+				<DesignerProperty Name="UseLegacyProvider" Value="False" />
+			</DesignerInfoPropertySet>
+		</edmx:Options>
+		<!-- Diagram content (shape and connector positions) -->
+		<edmx:Diagrams>
+		</edmx:Diagrams>
+	</edmx:Designer>
 </edmx:Edmx>

--- a/src/LazyEntityGraph.EntityFramework.Tests.Edmx/BlogModel.edmx.diagram
+++ b/src/LazyEntityGraph.EntityFramework.Tests.Edmx/BlogModel.edmx.diagram
@@ -16,6 +16,7 @@
         <InheritanceConnector EntityType="LazyEntityGraph.EntityFramework.Tests.Edmx.Story" />
         <AssociationConnector Association="LazyEntityGraph.EntityFramework.Tests.Edmx.UserContactDetails" />
         <AssociationConnector Association="LazyEntityGraph.EntityFramework.Tests.Edmx.PostCategory" />
+        <AssociationConnector Association="LazyEntityGraph.EntityFramework.Tests.Edmx.UserDefaultCategory" />
       </Diagram>
     </edmx:Diagrams>
   </edmx:Designer>

--- a/src/LazyEntityGraph.EntityFramework.Tests.Edmx/ModelMetadataGeneratorTests.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests.Edmx/ModelMetadataGeneratorTests.cs
@@ -46,7 +46,8 @@ namespace LazyEntityGraph.EntityFramework.Tests.Edmx
                 ExpectedConstraints.CreateOneToOne<User, ContactDetails>(u => u.ContactDetails, c => c.User),
                 ExpectedConstraints.CreateOneToOne<ContactDetails, User>(c => c.User, u => u.ContactDetails),
                 ExpectedConstraints.CreateForeignKey<Post, User, int>(p => p.Poster, p => p.PosterId, u => u.Id),
-                ExpectedConstraints.CreateForeignKey<ContactDetails, User, int>(c => c.User, c => c.UserId, u => u.Id)
+                ExpectedConstraints.CreateForeignKey<ContactDetails, User, int>(c => c.User, c => c.UserId, u => u.Id),
+                ExpectedConstraints.CreateForeignKey<User, Category, int>(u => u.DefaultCategory, u => u.DefaultCategoryId, c => c.Id)
             };
 
             // act

--- a/src/LazyEntityGraph.EntityFramework.Tests.Edmx/User.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests.Edmx/User.cs
@@ -21,9 +21,11 @@ namespace LazyEntityGraph.EntityFramework.Tests.Edmx
         }
     
         public int Id { get; set; }
+        public int DefaultCategoryId { get; set; }
     
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Post> Posts { get; set; }
         public virtual ContactDetails ContactDetails { get; set; }
+        public virtual Category DefaultCategory { get; set; }
     }
 }

--- a/src/LazyEntityGraph.EntityFramework.Tests/BlogModel.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests/BlogModel.cs
@@ -19,6 +19,9 @@ namespace LazyEntityGraph.EntityFramework.Tests
         public virtual ContactDetails ContactDetails { get; set; }
 
         public virtual ICollection<Post> Posts { get; set; }
+
+        public int DefaultCategoryId { get; set; }
+        public virtual Category DefaultCategory { get; set; }
     }
 
     public class ContactDetails
@@ -45,7 +48,7 @@ namespace LazyEntityGraph.EntityFramework.Tests
 
     public class Story : Post
     {
-        
+
     }
 
     public class Tag : Entity
@@ -79,6 +82,11 @@ namespace LazyEntityGraph.EntityFramework.Tests
                 .HasMany(u => u.Posts)
                 .WithRequired(p => p.Poster)
                 .HasForeignKey(p => p.PosterId);
+
+            modelBuilder.Entity<User>()
+                .HasRequired(u => u.DefaultCategory)
+                .WithMany()
+                .HasForeignKey(u => u.DefaultCategoryId);
 
             modelBuilder.Entity<ContactDetails>()
                 .HasRequired(cd => cd.User)

--- a/src/LazyEntityGraph.EntityFramework.Tests/EndToEndTests.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests/EndToEndTests.cs
@@ -41,6 +41,13 @@ namespace LazyEntityGraph.EntityFramework.Tests
         }
 
         [Theory, BlogModelData]
+        public void ForeignKeyPropertyOnOneSided(User user)
+        {
+            // assert
+            user.DefaultCategory.Id.Should().Be(user.DefaultCategoryId);
+        }
+
+        [Theory, BlogModelData]
         public void ForeignKeyPropertyOnDerivedOneToManyObjectFirst(Story story)
         {
             var relatedPosterId = story.Poster.Id;

--- a/src/LazyEntityGraph.EntityFramework.Tests/ModelMetadataGeneratorTests.cs
+++ b/src/LazyEntityGraph.EntityFramework.Tests/ModelMetadataGeneratorTests.cs
@@ -45,7 +45,8 @@ namespace LazyEntityGraph.EntityFramework.Tests
                 ExpectedConstraints.CreateOneToOne<User, ContactDetails>(u => u.ContactDetails, c => c.User),
                 ExpectedConstraints.CreateOneToOne<ContactDetails, User>(c => c.User, u => u.ContactDetails),
                 ExpectedConstraints.CreateForeignKey<Post, User, int>(p => p.Poster, p => p.PosterId, u => u.Id),
-                ExpectedConstraints.CreateForeignKey<ContactDetails, User, int>(c => c.User, c => c.UserId, u => u.Id)
+                ExpectedConstraints.CreateForeignKey<ContactDetails, User, int>(c => c.User, c => c.UserId, u => u.Id),
+                ExpectedConstraints.CreateForeignKey<User, Category, int>(u => u.DefaultCategory, u => u.DefaultCategoryId, c => c.Id)
             };
 
             // act

--- a/src/LazyEntityGraph.EntityFrameworkCore.Tests/BlogModel.cs
+++ b/src/LazyEntityGraph.EntityFrameworkCore.Tests/BlogModel.cs
@@ -19,6 +19,9 @@ namespace LazyEntityGraph.EntityFrameworkCore.Tests
         public virtual ContactDetails ContactDetails { get; set; }
 
         public virtual ICollection<Post> Posts { get; set; }
+
+        public int DefaultCategoryId { get; set; }
+        public virtual Category DefaultCategory { get; set; }
     }
 
     public class ContactDetails
@@ -40,10 +43,10 @@ namespace LazyEntityGraph.EntityFrameworkCore.Tests
 
         public virtual ICollection<Category> Categories { get; set; }
     }
-   
+
     public class Story : Post
     {
-        
+
     }
 
     public class Category : Entity
@@ -66,6 +69,11 @@ namespace LazyEntityGraph.EntityFrameworkCore.Tests
                 .HasMany(u => u.Posts)
                 .WithOne(p => p.Poster).IsRequired()
                 .HasForeignKey(p => p.PosterId);
+
+            modelBuilder.Entity<User>()
+                .HasOne(u => u.DefaultCategory)
+                .WithMany()
+                .HasForeignKey(u => u.DefaultCategoryId);
 
             modelBuilder.Entity<ContactDetails>()
                 .HasOne(cd => cd.User)

--- a/src/LazyEntityGraph.EntityFrameworkCore.Tests/EndToEndTests.cs
+++ b/src/LazyEntityGraph.EntityFrameworkCore.Tests/EndToEndTests.cs
@@ -40,6 +40,13 @@ namespace LazyEntityGraph.EntityFrameworkCore.Tests
         }
 
         [Theory, BlogModelData]
+        public void ForeignKeyPropertyOnOneSided(User user)
+        {
+            // assert
+            user.DefaultCategory.Id.Should().Be(user.DefaultCategoryId);
+        }
+
+        [Theory, BlogModelData]
         public void ForeignKeyPropertyOnDerivedOneToManyObjectFirst(Story story)
         {
             var relatedPosterId = story.Poster.Id;

--- a/src/LazyEntityGraph.EntityFrameworkCore.Tests/LazyEntityGraph.EntityFrameworkCore.Tests.csproj
+++ b/src/LazyEntityGraph.EntityFrameworkCore.Tests/LazyEntityGraph.EntityFrameworkCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="[4.2.0,5)" />
@@ -16,7 +16,12 @@
     <ProjectReference Include="..\LazyEntityGraph.EntityFrameworkCore\LazyEntityGraph.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\LazyEntityGraph.TestUtils\LazyEntityGraph.TestUtils.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.0,3)" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[2.1.0,3)" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="[2.1.0,3)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.0,3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[2.1.0,3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="[2.1.0,3)" />
@@ -25,6 +30,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.4,4)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"  Version="[3.1.4,4)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools"  Version="[3.1.4,4)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.4,6)" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"  Version="[5.0.4,6)" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Tools"  Version="[5.0.4,6)" />
   </ItemGroup>
 </Project>
 

--- a/src/LazyEntityGraph.EntityFrameworkCore.Tests/ModelMetadataGeneratorTests.cs
+++ b/src/LazyEntityGraph.EntityFrameworkCore.Tests/ModelMetadataGeneratorTests.cs
@@ -43,7 +43,8 @@ namespace LazyEntityGraph.EntityFrameworkCore.Tests
                 ExpectedConstraints.CreateOneToOne<User, ContactDetails>(u => u.ContactDetails, c => c.User),
                 ExpectedConstraints.CreateOneToOne<ContactDetails, User>(c => c.User, u => u.ContactDetails),
                 ExpectedConstraints.CreateForeignKey<Post, User, int>(p => p.Poster, p => p.PosterId, u => u.Id),
-                ExpectedConstraints.CreateForeignKey<ContactDetails, User, int>(c => c.User, c => c.UserId, u => u.Id)
+                ExpectedConstraints.CreateForeignKey<ContactDetails, User, int>(c => c.User, c => c.UserId, u => u.Id),
+                ExpectedConstraints.CreateForeignKey<User, Category, int>(u => u.DefaultCategory, u => u.DefaultCategoryId, c => c.Id)
             };
 
             // act

--- a/src/LazyEntityGraph.Tests/Integration/FooBar.cs
+++ b/src/LazyEntityGraph.Tests/Integration/FooBar.cs
@@ -27,7 +27,12 @@ namespace LazyEntityGraph.Tests.Integration
         public virtual ICollection<Foo> Foos { get; set; }
     }
 
-    public class Faz : Foo
+    public class Faz : Foo { }
+
+    public class Baz
     {
+        public int FooId { get; set; }
+
+        public virtual Foo Foo { get; set; }
     }
 }

--- a/src/LazyEntityGraph.Tests/Integration/ForeignKeyConstraintTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/ForeignKeyConstraintTest.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using LazyEntityGraph.Core.Constraints;
 using AutoFixture;
 using Xunit;
 using LazyEntityGraph.TestUtils;
@@ -55,27 +54,55 @@ namespace LazyEntityGraph.Tests.Integration
         {
             // arrange
             var fixture = IntegrationTest.GetFixture(ExpectedConstraints.CreateForeignKey<Foo, Bar, int>(f => f.Bar, f => f.BarId, b => b.Id));
-            var foo = fixture.Create<Faz>();
+            var faz = fixture.Create<Faz>();
 
             // act
-            var bar = foo.Bar;
+            var bar = faz.Bar;
 
             // assert
-            foo.BarId.Should().Be(bar.Id);
+            faz.BarId.Should().Be(bar.Id);
         }
         [Fact]
         public void SetsDerivedPropertyToPOCOProperty()
         {
             // arrange
             var fixture = IntegrationTest.GetFixture(ExpectedConstraints.CreateForeignKey<Foo, Bar, int>(f => f.Bar, f => f.BarId, b => b.Id));
-            var foo = fixture.Create<Faz>();
+            var faz = fixture.Create<Faz>();
             var bar = new Bar() { Id = fixture.Create<int>() };
 
             // act
-            foo.Bar = bar;
+            faz.Bar = bar;
 
             // assert
-            foo.BarId.Should().Be(bar.Id);
+            faz.BarId.Should().Be(bar.Id);
+        }
+
+        [Fact]
+        public void SetsOneSidedPropertyToGeneratedProxyProperty()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(ExpectedConstraints.CreateForeignKey<Baz, Foo, int>(b => b.Foo, b => b.FooId, f => f.Id));
+            var baz = fixture.Create<Baz>();
+
+            // act
+            var foo = baz.Foo;
+
+            // assert
+            baz.FooId.Should().Be(foo.Id);
+        }
+        [Fact]
+        public void SetsOneSidedPropertyToPOCOProperty()
+        {
+            // arrange
+            var fixture = IntegrationTest.GetFixture(ExpectedConstraints.CreateForeignKey<Baz, Foo, int>(b => b.Foo, b => b.FooId, f => f.Id));
+            var baz = fixture.Create<Baz>();
+            var foo = new Foo() { Id = fixture.Create<int>() };
+
+            // act
+            baz.Foo = foo;
+
+            // assert
+            baz.FooId.Should().Be(foo.Id);
         }
 
         [Fact]

--- a/src/LazyEntityGraph.Tests/Integration/IntegrationTest.cs
+++ b/src/LazyEntityGraph.Tests/Integration/IntegrationTest.cs
@@ -14,7 +14,7 @@ namespace LazyEntityGraph.Tests.Integration
         {
             var customization = new LazyEntityGraphCustomization(
                 new ModelMetadata(
-                    new[] { typeof(Foo), typeof(Bar), typeof(Faz) },
+                    new[] { typeof(Foo), typeof(Bar), typeof(Faz), typeof(Baz) },
                     constraints));
 
             var fixture = new Fixture();


### PR DESCRIPTION
Adds support for navigation properties that don't have an inverse navigation property, as in the following example:
```c#
class Foo
{
    public int Id { get; set; }
    public int BarId { get; set; }
    public virtual Bar Bar { get; set; }
}
class Bar
{
    public int Id { get; set; }
}
class Context : DbContext
{
    void OnModelCreating(ModelBuilder builder)
    {
        builder.Entity<Foo>()
               .HasOne(f => f.Bar)
               .WithMany()
               .HasForeignKey(f => f.BarId);
    }
}
```
Fixes #29 